### PR TITLE
Additional checks

### DIFF
--- a/idiot/__init__.py
+++ b/idiot/__init__.py
@@ -8,8 +8,8 @@ import random
 from scruffy import *
 from Foundation import *
 
-OK_TITLES = [u"😏", u"😁", u"😃", u"😄", u"😆"]
-NOT_OK_TITLES = [u"🚑"]
+OK_TITLES = [u"😏", u"😁", u"😃", u"😄", u"😆", u"🤘", u"👌"]
+NOT_OK_TITLES = [u"🚑",u"🖕"]
 
 
 def init():

--- a/idiot/checks/FileSharing.py
+++ b/idiot/checks/FileSharing.py
@@ -1,0 +1,81 @@
+"""
+Idiot check for FileSharing via SMB or AFP is on
+
+purpose: indicates if Sharing Preferences: File Sharing using SMB or AFP is 
+    permitted to this machine
+
+daemons: 
+    /usr/sbin/AppleFileServer
+    /usr/sbin/smbd
+
+requirement: oversharing is always bad
+
+
+These are managed by launchd (as seen below) but I'm not sure how just yet. Not 
+directly but from something else.
+
+$ sudo lsof -n -i tcp:548
+COMMAND    PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+launchd      1  root   30u  IPv4 0x57975ec6347d4d57      0t0  TCP *:afpovertcp (LISTEN)
+launchd      1  root   63u  IPv6 0x57975ec62c9c40b7      0t0  TCP *:afpovertcp (LISTEN)
+AppleFile 4704  root    3u  IPv4 0x57975ec6347d4d57      0t0  TCP *:afpovertcp (LISTEN)
+AppleFile 4704  root    4u  IPv6 0x57975ec62c9c40b7      0t0  TCP *:afpovertcp (LISTEN)
+AppleFile 4704  root   12u  IPv6 0x57975ec62c9c4617      0t0  TCP [::1]:afpovertcp->[::1]:51743 (ESTABLISHED)
+
+$ ps -ax |grep -i AppleFile
+ 4704 ??         0:00.05 /usr/sbin/AppleFileServer
+
+
+$ sudo lsof -n -i tcp:445
+COMMAND  PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+launchd    1  root   67u  IPv4 0x57975ec62ea0a65f      0t0  TCP *:microsoft-ds (LISTEN)
+launchd    1  root   68u  IPv6 0x57975ec62c9c4b77      0t0  TCP *:microsoft-ds (LISTEN)
+smbd    4967  root    4u  IPv4 0x57975ec62ea0a65f      0t0  TCP *:microsoft-ds (LISTEN)
+smbd    4967  root    5u  IPv6 0x57975ec62c9c4b77      0t0  TCP *:microsoft-ds (LISTEN)
+smbd    4967  root    6u  IPv6 0x57975ec62c9c4617      0t0  TCP [::1]:microsoft-ds->[::1]:51853 (ESTABLISHED)
+
+$ ps -ax |grep -i smb
+ 4728 ??         0:00.01 /usr/sbin/smbd
+
+
+Might be from com.apple.sharingd although I think that's more client functions for mDNS-happy sharing fun
+"""
+
+import psutil
+import re
+
+from idiot import CheckPlugin
+
+
+class FileSharingCheck(CheckPlugin):
+    name = "FileSharing"
+
+    def run(self):
+        """
+        Run the check.
+
+        All check scripts must implement this method. It must return a tuple of:
+        (<success>, <message>)
+
+        In this example, if the check succeeds and FileSharing processes are nowhere
+        to be found, the check will return (True, "No FileSharing processes found").
+
+        If the check fails and an FileSharing process is found, it returns
+        (False, "Found SMB or AFP FileSharing processes with pids <pids>")
+        """
+        pids = []
+        for p in psutil.process_iter():
+            try:
+                if (p.name() == 'AppleFileServer' or p.name() == 'smbd'):
+                    pids.append(p.pid)
+            except psutil.NoSuchProcess:
+                pass
+
+        if len(pids):
+            return (False, "Found SMB or AFP FileSharing processes with pids: {} - Disable Sharing Prefs: File Sharing".format(', '.join([str(p) for p in pids])))
+        else:
+            return (True, "FileSharing is disabled")
+
+
+if __name__ == "__main__":
+    print(FileSharingCheck().run())

--- a/idiot/checks/RemoteManagement.py
+++ b/idiot/checks/RemoteManagement.py
@@ -1,0 +1,51 @@
+"""
+Idiot check for Apple Remote Desktop management with ARDAgent
+
+purpose: indicates if Sharing Preferences: Remote Management using Apple Remote Desktop management is permitted to this
+    machine
+
+daemon: 
+    /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/MacOS/ARDAgent
+
+requirement: ARD permits remote execution and beyond as the accessing or 
+    logged in user. Also permits remote console/interactive access of course
+"""
+
+import psutil
+import re
+
+from idiot import CheckPlugin
+
+
+class ARDAgentCheck(CheckPlugin):
+    name = "ARDAgent"
+
+    def run(self):
+        """
+        Run the check.
+
+        All check scripts must implement this method. It must return a tuple of:
+        (<success>, <message>)
+
+        In this example, if the check succeeds and the ARDAgent process is nowhere
+        to be found, the check will return (True, "No ARDAgent processes found").
+
+        If the check fails and an ARDAgent process is found, it returns
+        (False, "Found ARDAgent processes with pids <pids>")
+        """
+        pids = []
+        for p in psutil.process_iter():
+            try:
+                if p.name() == 'ARDAgent':
+                    pids.append(p.pid)
+            except psutil.NoSuchProcess:
+                pass
+
+        if len(pids):
+            return (False, "Found ARDAgent processes with pids: {} - Disable Sharing Prefs: Remote Management".format(', '.join([str(p) for p in pids])))
+        else:
+            return (True, "ARDAgent is disabled")
+
+
+if __name__ == "__main__":
+    print(ARDAgentCheck().run())

--- a/idiot/checks/ScreenSharing.py
+++ b/idiot/checks/ScreenSharing.py
@@ -1,0 +1,77 @@
+"""
+Idiot check for ScreenSharing
+
+purpose: indicates if Sharing Preferences: Screen Sharing / VNC is permitted to 
+    this machine
+
+daemons:
+    /System/Library/CoreServices/RemoteManagement/screensharingd.bundle/Contents/MacOS/screensharingd
+    /System/Library/CoreServices/RemoteManagement/ScreensharingAgent.bundle/Contents/MacOS/ScreensharingAgent
+
+requirement: ScreenSharing permits remote console/interactive access.
+
+info:
+Detecting this is tricky because until it's accessed neither of the above are 
+forked as processes visible in process table. Once a system has been accessed, 
+though, these processes remain until Sharing:Screen Sharing is disabled
+
+ Might need to read defaults or a plist instead.
+ $ sudo lsof -n -i:5900
+ is also good but insane
+
+ Actually the *right* way to do this is by calling launchctl
+
+ $ launchctl list 
+
+ $ launchctl print system/com.apple.screensharing state
+
+If it's enabled then properties will be returned including
+
+state = waiting
+
+Which seems to indicate it's configured to spawn screensharingd
+If it's not enabled in Sharing prefs nothing will be returned
+
+$ launchctl print system/com.apple.screensharing state
+Could not find service "com.apple.screensharing" in domain for system
+
+"""
+
+import psutil
+import re
+
+from idiot import CheckPlugin
+
+
+class ScreenSharingCheck(CheckPlugin):
+    name = "ScreenSharing"
+
+    def run(self):
+        """
+        Run the check.
+
+        All check scripts must implement this method. It must return a tuple of:
+        (<success>, <message>)
+
+        In this example, if the check succeeds and the ScreenSharing process is nowhere
+        to be found, the check will return (True, "No ScreenSharing processes found").
+
+        If the check fails and an ScreenSharing process is found, it returns
+        (False, "Found ScreenSharing processes with pids <pids>")
+        """
+        pids = []
+        for p in psutil.process_iter():
+            try:
+                if (p.name() == 'ScreensharingAgent' or p.name() == 'screensharingd'):
+                    pids.append(p.pid)
+            except psutil.NoSuchProcess:
+                pass
+
+        if len(pids):
+            return (False, "Found ScreenSharing processes with pids: {} - Disable Sharing Prefs: Screen Sharing".format(', '.join([str(p) for p in pids])))
+        else:
+            return (True, "ScreenSharing is disabled")
+
+
+if __name__ == "__main__":
+    print(ScreenSharingCheck().run())

--- a/idiot/checks/apache.py
+++ b/idiot/checks/apache.py
@@ -18,10 +18,10 @@ class ApacheCheck(CheckPlugin):
         All check scripts must implement this method. It must return a tuple of:
         (<success>, <message>)
 
-        In this example, if the check succeeds and the apache process is nowhere
+        In this example, if the check succeeds and the Apache process is nowhere
         to be found, the check will return (True, "No httpd processes found").
 
-        If the check fails and an apache process is found, it returns
+        If the check fails and an Apache process is found, it returns
         (False, "Found httpd processes with pids <pids>")
         """
         pids = []

--- a/idiot/checks/sshd.py
+++ b/idiot/checks/sshd.py
@@ -1,0 +1,75 @@
+"""
+Idiot check for sshd / Remote Login
+
+purpose: indicates if "Sharing Preferences: Remote Login" or OpenSSH's sshd is
+    otherwise running
+
+daemon: 
+    /usr/sbin/sshd
+
+requirement: sshd provides interactive access with valid creds. Best left off.
+
+
+
+info:
+Detecting this is tricky because until it's accessed launchd hasn't 
+forked the sshd process so there's nothing visible in process table. 
+While a system is being accessed (or scanned even), though, the sshd process
+is visible. Once a session ends (or login times out) the sshd process exits
+leaving launchd to listen for the SSH client to connect
+
+The correct way to check for this being enabled is using launchctl 
+checking output of:
+
+$ launchctl print system/com.openssh.sshd state
+
+which would have state = waiting which indicates it's configured to spawn sshd.
+If it's not enabled in Sharing prefs nothing will be returned:
+
+    $ launchctl print system/com.openssh.sshd state
+    Could not find service "com.openssh.sshd" in domain for system
+
+checking the pid is easier and, much more importantly, would catch
+a manually invoked sshd left behind from, say, an rsync serving or a breach
+(you pick)
+
+"""
+
+import psutil
+import re
+
+from idiot import CheckPlugin
+
+
+class sshdCheck(CheckPlugin):
+    name = "sshd"
+
+    def run(self):
+        """
+        Run the check.
+
+        All check scripts must implement this method. It must return a tuple of:
+        (<success>, <message>)
+
+        In this example, if the check succeeds and the sshd process is nowhere
+        to be found, the check will return (True, "No sshd processes found").
+
+        If the check fails and an sshd process is found, it returns
+        (False, "Found sshd processes with pids <pids>")
+        """
+        pids = []
+        for p in psutil.process_iter():
+            try:
+                if p.name() == 'sshd':
+                    pids.append(p.pid)
+            except psutil.NoSuchProcess:
+                pass
+
+        if len(pids):
+            return (False, "Found sshd processes with pids: {} - Disable Sharing Prefs: Remote Login".format(', '.join([str(p) for p in pids])))
+        else:
+            return (True, "sshd is disabled")
+
+
+if __name__ == "__main__":
+    print(sshdCheck().run())

--- a/idiot/config/default.conf
+++ b/idiot/config/default.conf
@@ -10,3 +10,5 @@ enabled:
     - VagrantCheck
     - ARDAgentCheck
     - sshdCheck
+    - FileSharingCheck
+    - ScreenSharingCheck

--- a/idiot/config/default.conf
+++ b/idiot/config/default.conf
@@ -8,3 +8,5 @@ enabled:
     - DockerMachineCheck
     - DockerCheck
     - VagrantCheck
+    - ARDAgentCheck
+    - sshdCheck


### PR DESCRIPTION
I made some checks based on the Apache check. My goal was to try to identify most of the items in OSX Sharing Preferences from System Preferences. Checks included are:
- Screen Sharing (VNC using OSX creds or VNC password) - ScreenSharing.py
- File Sharing (SMB and AFP file services) - FileSharing.py
- Remote Login (SSH) - sshd.py
- Remote Management (Using Apple Remote Desktop Agent / ARDAgent) - RemoteManagement.py
