### PR TITLE
Updated Checks

### DIFF
--- a/idiot/checks/FileSharing.py
+++ b/idiot/checks/FileSharing.py
@@ -1,5 +1,8 @@
 """
-Idiot check for FileSharing via SMB or AFP is on
+Idiot check if FileSharing via SMB or AFP is on
+
+NOTE: Currently this is only detected if it's been accessed by a client causing launchd
+to spawn AppleFileServer or smbd. Fixed soon.
 
 purpose: indicates if Sharing Preferences: File Sharing using SMB or AFP is 
     permitted to this machine
@@ -10,7 +13,10 @@ daemons:
 
 requirement: oversharing is always bad
 
+Currently this is only detected if it's been accessed by a client causing launchd
+to spawn AppleFileServer or smbd.
 
+Info:
 These are managed by launchd (as seen below) but I'm not sure how just yet. Not 
 directly but from something else.
 
@@ -38,7 +44,6 @@ $ ps -ax |grep -i smb
  4728 ??         0:00.01 /usr/sbin/smbd
 
 
-Might be from com.apple.sharingd although I think that's more client functions for mDNS-happy sharing fun
 """
 
 import psutil

--- a/idiot/checks/RemoteManagement.py
+++ b/idiot/checks/RemoteManagement.py
@@ -9,43 +9,53 @@ daemon:
 
 requirement: ARD permits remote execution and beyond as the accessing or 
     logged in user. Also permits remote console/interactive access of course
+    This checks both launchd enabling ARDAgent and manually starting ARDAgent
+    ARDAgent is defined in launchd (seen in launchctl list but doesn't output config
+    from a launchctl print. The PID-based check is what actually detects ARDAgent
+    but we're going to leave the launchctl one in for now too (but disable it).
+
 """
-
+import logging
+import subprocess
+import os
 import psutil
-import re
 
+import idiot
 from idiot import CheckPlugin
 
+log = logging.getLogger()
 
-class ARDAgentCheck(CheckPlugin):
-    name = "ARDAgent"
+class RemoteManagementCheck(CheckPlugin):
+    name = "Remote Management"
 
     def run(self):
+        
         """
-        Run the check.
-
-        All check scripts must implement this method. It must return a tuple of:
-        (<success>, <message>)
-
-        In this example, if the check succeeds and the ARDAgent process is nowhere
-        to be found, the check will return (True, "No ARDAgent processes found").
-
-        If the check fails and an ARDAgent process is found, it returns
-        (False, "Found ARDAgent processes with pids <pids>")
-        """
+        with open(os.devnull, 'w') as devnull:
+            try:
+                # If the service is disabled in Preferences
+                # the query returns a non-zero error
+                # should use this query better in future
+                if subprocess.check_call(['launchctl', 'print', 'system/com.apple.RemoteDesktop.agent', 'state'], stdout=devnull, stderr=devnull):
+                    pass
+                else:
+                    return (False, "enabled in Sharing Prefs: Remote Management")           
+            except subprocess.CalledProcessError as e:
+                # this only gets run if myproc isn't enabled by
+                # launchd as checked above
+                """
         pids = []
         for p in psutil.process_iter():
             try:
-                if p.name() == 'ARDAgent':
+                if p.name() == "ARDAgent":
                     pids.append(p.pid)
             except psutil.NoSuchProcess:
                 pass
-
         if len(pids):
-            return (False, "Found ARDAgent processes with pids: {} - Disable Sharing Prefs: Remote Management".format(', '.join([str(p) for p in pids])))
+            return (False, "enabled in Sharing Prefs: Remote Management - pids: {}".format(', '.join([str(p) for p in pids])))
         else:
-            return (True, "ARDAgent is disabled")
-
+            return (True, "disabled")
 
 if __name__ == "__main__":
-    print(ARDAgentCheck().run())
+    idiot.init()
+    print(RemoteManagementCheck().run())

--- a/idiot/checks/RemoteManagement.py
+++ b/idiot/checks/RemoteManagement.py
@@ -12,7 +12,7 @@ requirement: ARD permits remote execution and beyond as the accessing or
     This checks both launchd enabling ARDAgent and manually starting ARDAgent
     ARDAgent is defined in launchd (seen in launchctl list but doesn't output config
     from a launchctl print. The PID-based check is what actually detects ARDAgent
-    but we're going to leave the launchctl one in for now too (but disable it).
+    but we'll try to check the launchctl one too later
 
 """
 import logging
@@ -29,21 +29,6 @@ class RemoteManagementCheck(CheckPlugin):
     name = "Remote Management"
 
     def run(self):
-        
-        """
-        with open(os.devnull, 'w') as devnull:
-            try:
-                # If the service is disabled in Preferences
-                # the query returns a non-zero error
-                # should use this query better in future
-                if subprocess.check_call(['launchctl', 'print', 'system/com.apple.RemoteDesktop.agent', 'state'], stdout=devnull, stderr=devnull):
-                    pass
-                else:
-                    return (False, "enabled in Sharing Prefs: Remote Management")           
-            except subprocess.CalledProcessError as e:
-                # this only gets run if myproc isn't enabled by
-                # launchd as checked above
-                """
         pids = []
         for p in psutil.process_iter():
             try:

--- a/idiot/checks/ScreenSharing.py
+++ b/idiot/checks/ScreenSharing.py
@@ -62,18 +62,6 @@ class ScreenSharingCheck(CheckPlugin):
             except subprocess.CalledProcessError as e:
                 # this only gets run if screensharing isn't enabled by
                 # launchd as checked above
-                """
-                pids = []
-                for p in psutil.process_iter():
-                    try:
-                        if (p.name() == 'ScreensharingAgent' or p.name() == 'screensharingd'):
-                            pids.append(p.pid)
-                    except psutil.NoSuchProcess:
-                        pass
-                if len(pids):
-                    return (False, "enabled manually - see pids: {} ".format(', '.join([str(p) for p in pids])))
-                else:
-                    """
                 return (True, "disabled")
 
 if __name__ == "__main__":

--- a/idiot/checks/ScreenSharing.py
+++ b/idiot/checks/ScreenSharing.py
@@ -9,69 +9,73 @@ daemons:
     /System/Library/CoreServices/RemoteManagement/ScreensharingAgent.bundle/Contents/MacOS/ScreensharingAgent
 
 requirement: ScreenSharing permits remote console/interactive access.
+This checks both launchd enabling the above and manually starting them.
 
 info:
+We're only checking launchd for this service. Not sure if this can be manually 
+invoked without it needing other launchd XPC kicked stuff like kdc.
+
 Detecting this is tricky because until it's accessed neither of the above are 
 forked as processes visible in process table. Once a system has been accessed, 
 though, these processes remain until Sharing:Screen Sharing is disabled
 
- Might need to read defaults or a plist instead.
- $ sudo lsof -n -i:5900
- is also good but insane
+ One way to check this is by calling launchctl
 
- Actually the *right* way to do this is by calling launchctl
+ $ launchctl print system/com.apple.screensharing
 
- $ launchctl list 
-
- $ launchctl print system/com.apple.screensharing state
-
-If it's enabled then properties will be returned including
+If it's enabled then properties will be returned (with return code 0) including
 
 state = waiting
 
 Which seems to indicate it's configured to spawn screensharingd
-If it's not enabled in Sharing prefs nothing will be returned
+
+If it's not enabled in Sharing prefs nothing will be returned (except a non-0
+return code like 113)
 
 $ launchctl print system/com.apple.screensharing state
 Could not find service "com.apple.screensharing" in domain for system
 
 """
-
+import logging
+import subprocess
+import os
 import psutil
-import re
 
+import idiot
 from idiot import CheckPlugin
 
+log = logging.getLogger()
 
 class ScreenSharingCheck(CheckPlugin):
-    name = "ScreenSharing"
+    name = "Screen Sharing"
 
     def run(self):
-        """
-        Run the check.
-
-        All check scripts must implement this method. It must return a tuple of:
-        (<success>, <message>)
-
-        In this example, if the check succeeds and the ScreenSharing process is nowhere
-        to be found, the check will return (True, "No ScreenSharing processes found").
-
-        If the check fails and an ScreenSharing process is found, it returns
-        (False, "Found ScreenSharing processes with pids <pids>")
-        """
-        pids = []
-        for p in psutil.process_iter():
+        with open(os.devnull, 'w') as devnull:
             try:
-                if (p.name() == 'ScreensharingAgent' or p.name() == 'screensharingd'):
-                    pids.append(p.pid)
-            except psutil.NoSuchProcess:
-                pass
-
-        if len(pids):
-            return (False, "Found ScreenSharing processes with pids: {} - Disable Sharing Prefs: Screen Sharing".format(', '.join([str(p) for p in pids])))
-        else:
-            return (True, "ScreenSharing is disabled")
-
+                # If the service is disabled in Preferences
+                # the query returns a non-zero error
+                # should use this query better in future
+                if subprocess.check_call(['launchctl', 'print', 'system/com.apple.screensharing'], stdout=devnull, stderr=devnull):
+                    return (True, "Dat")
+                else:
+                    return (False, "enabled in Sharing Prefs: Screen Sharing")           
+            except subprocess.CalledProcessError as e:
+                # this only gets run if screensharing isn't enabled by
+                # launchd as checked above
+                """
+                pids = []
+                for p in psutil.process_iter():
+                    try:
+                        if (p.name() == 'ScreensharingAgent' or p.name() == 'screensharingd'):
+                            pids.append(p.pid)
+                    except psutil.NoSuchProcess:
+                        pass
+                if len(pids):
+                    return (False, "enabled manually - see pids: {} ".format(', '.join([str(p) for p in pids])))
+                else:
+                    """
+                return (True, "disabled")
 
 if __name__ == "__main__":
+    idiot.init()
     print(ScreenSharingCheck().run())

--- a/idiot/checks/sshd.py
+++ b/idiot/checks/sshd.py
@@ -1,15 +1,14 @@
 """
 Idiot check for sshd / Remote Login
 
-purpose: indicates if "Sharing Preferences: Remote Login" or OpenSSH's sshd is
-    otherwise running
+purpose: indicates if "Sharing Preferences: Remote Login" is enabled or 
+    OpenSSH's sshd is otherwise running
 
 daemon: 
     /usr/sbin/sshd
 
 requirement: sshd provides interactive access with valid creds. Best left off.
-
-
+This checks both launchd enabling sshd and manually starting sshd.
 
 info:
 Detecting this is tricky because until it's accessed launchd hasn't 
@@ -18,58 +17,49 @@ While a system is being accessed (or scanned even), though, the sshd process
 is visible. Once a session ends (or login times out) the sshd process exits
 leaving launchd to listen for the SSH client to connect
 
-The correct way to check for this being enabled is using launchctl 
-checking output of:
-
-$ launchctl print system/com.openssh.sshd state
-
-which would have state = waiting which indicates it's configured to spawn sshd.
-If it's not enabled in Sharing prefs nothing will be returned:
-
-    $ launchctl print system/com.openssh.sshd state
-    Could not find service "com.openssh.sshd" in domain for system
-
 checking the pid is easier and, much more importantly, would catch
 a manually invoked sshd left behind from, say, an rsync serving or a breach
 (you pick)
 
 """
-
+import logging
+import subprocess
+import os
 import psutil
-import re
 
+import idiot
 from idiot import CheckPlugin
 
+log = logging.getLogger()
 
-class sshdCheck(CheckPlugin):
+class SSHDCheck(CheckPlugin):
     name = "sshd"
 
     def run(self):
-        """
-        Run the check.
-
-        All check scripts must implement this method. It must return a tuple of:
-        (<success>, <message>)
-
-        In this example, if the check succeeds and the sshd process is nowhere
-        to be found, the check will return (True, "No sshd processes found").
-
-        If the check fails and an sshd process is found, it returns
-        (False, "Found sshd processes with pids <pids>")
-        """
-        pids = []
-        for p in psutil.process_iter():
+        with open(os.devnull, 'w') as devnull:
             try:
-                if p.name() == 'sshd':
-                    pids.append(p.pid)
-            except psutil.NoSuchProcess:
-                pass
-
-        if len(pids):
-            return (False, "Found sshd processes with pids: {} - Disable Sharing Prefs: Remote Login".format(', '.join([str(p) for p in pids])))
-        else:
-            return (True, "sshd is disabled")
-
+                # If the service is disabled in Preferences
+                # the query returns a non-zero error
+                # should use this query better in future
+                if subprocess.check_call(['launchctl', 'print', 'system/com.openssh.sshd'], stdout=devnull, stderr=devnull):
+                    return (True, "Dat")
+                else:
+                    return (False, "enabled in Sharing Prefs: Remote Login")           
+            except subprocess.CalledProcessError as e:
+                # this only gets run if sshd isn't enabled by
+                # launchd as checked above
+                pids = []
+                for p in psutil.process_iter():
+                    try:
+                        if p.name() == 'sshd':
+                            pids.append(p.pid)
+                    except psutil.NoSuchProcess:
+                        pass
+                if len(pids):
+                    return (False, "enabled manually - see pids: {} ".format(', '.join([str(p) for p in pids])))
+                else:
+                    return (True, "disabled")
 
 if __name__ == "__main__":
-    print(sshdCheck().run())
+    idiot.init()
+    print(SSHDCheck().run())

--- a/idiot/config/default.conf
+++ b/idiot/config/default.conf
@@ -8,7 +8,6 @@ enabled:
     - DockerMachineCheck
     - DockerCheck
     - VagrantCheck
-    - ARDAgentCheck
-    - sshdCheck
-    - FileSharingCheck
+    - RemoteManagementCheck
+    - SSHDCheck
     - ScreenSharingCheck


### PR DESCRIPTION
SSHD, Screen Sharing and Remote Management checks for both launchd and pids where possible.

Hey these are updated. I manually added your changes (sshdCheck to SSHDCheck etc.) to my fork I think. I will rebase on your merge or I need to work out how to do this right :-)

We should start making a table like this:

| Proc | Checkable by launchctl specifier query | checkable by psutil pid | checkable by pidfile |
| --- | --- | --- | --- |
| sshd / Remote Access | yes for system/com.openssh.sshd | yes (if spawned) | ? |
| Screen Sharing | yes for system/com.apple.screensharing | yes (if spawned) | ? |
| Remote Management / ARDAgent | not that I can see | yes as ARDAgent | ? |
| File Sharing / AppleFIleServer and smbd | not so far - appears to be an launchd XPC service | yes (if spawned) | kdc in /System/Library/ LaunchDaemons/ com.apple.Kerberos.kdc.plist |

In the checks logic I use around launchctl is kinda weird. I'm just testing for its successful execution of a query. It's going to assume that any failure there (like not being able to query launchd for example) means a launchd-spawned service isn't on. Not sure what happens to those if launchd dies. Pretty sure a lot of other stuff will be majorly angry if it does anyway.

Anyway for SSHD I check launchd first and I also check for pids if it's not running from launchd. It will report only one of those conditions with the Sharing one first. 

I think the right way to do this would be to check both, accumulate the results and then return based on that. For that matter I think the pids and launchctl-type checks could be good central functions somewhere since we're just reusing those pretty much the same way in each check at the moment.
