### PR TITLE
Checks: Add redis to check list

### DIFF
--- a/idiot/checks/redis.py
+++ b/idiot/checks/redis.py
@@ -1,0 +1,15 @@
+"""
+Checks to ensure redis is not running
+"""
+
+import idiot
+from idiot import ProcessCheck
+
+
+class RedisCheck(ProcessCheck):
+    name = "Redis"
+    process_names = ["redis-server"]
+
+
+if __name__ == "__main__":
+    print(RedisCheck().run())


### PR DESCRIPTION
This change ensures `redis-server` is also detected. The apache/httpd check was used as a base.
